### PR TITLE
change to simpler download model - strict checking required for now

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -18,3 +18,12 @@ bin_dir: /opt/kubernetes/server/bin
 config_dir: /etc/kubernetes
 log_dir: /var/log/kubernetes
 
+# locations of downloads
+source:
+  url: "https://storage.googleapis.com/kubernetes-release/release/{{ k8s.version }}/bin/linux/amd64"
+  checksum:
+    v1.3.3:
+      kube-apiserver: "sha256:a4816d0cde65368ce211464b2e85932e963caac54bcc12911b945b75d11366fc"
+      kube-controller-manager: "sha256:16aefb8facdaf98e348b5c83e7972c6786aad326c9cae5846b66c87a174e55c5"
+      kubectl: "sha256:7ecb4ce0af38d847cdc4976f72530c73b4533a8b973489b92508363566dcfd61"
+      kube-scheduler: "sha256:9047e0f76ce615b2c9c83bf798470d0356536dd460f31be6cddff7b3ecf14a12"

--- a/rebar.yml
+++ b/rebar.yml
@@ -77,12 +77,6 @@ roles:
         schema:
           type: str
           required: true
-      - name: k8s-cache
-        description: "Kubernetes Cache"
-        default: "/tftpboot/cache/kubernetes"
-        schema:
-          type: str
-          required: true
       - name: k8s-strict
         description: "The Kubernetes Checksum Required"
         default: true
@@ -145,10 +139,7 @@ roles:
       - rebar-installed-node
       - k8s-config
     wants-attribs:
-      - k8s-cache
       - k8s-account
-      - k8s-version
-      - k8s-strict
     metadata:
       role_role_map:
         k8s-prereqs:
@@ -213,6 +204,7 @@ roles:
     wants-attribs:
       - k8s-account
       - k8s-version
+      - k8s-strict
       - k8s-log-level
       - k8s-cluster_service_ips
       - k8s-apiserver-port
@@ -271,6 +263,8 @@ roles:
       - cert-ca-install-root
       - cert-ca-signed-cert
     wants-attribs:
+      - k8s-version
+      - k8s-strict
       - k8s-apiserver-insecure_port
       - k8s-cluster_name
       - k8s-cluster_ips
@@ -309,6 +303,8 @@ roles:
       - k8s-config
       - k8s-apiserver
     wants-attribs:
+      - k8s-version
+      - k8s-strict
       - k8s-apiserver-insecure_port
       - k8s-log-level
       - k8s-master-network

--- a/roles/apiserver/tasks/debug.yml
+++ b/roles/apiserver/tasks/debug.yml
@@ -32,8 +32,15 @@
 - name: "DEBUG: K8s"
   debug: var=k8s
 
-- name: "DEBUG: Downloads Source"
-  debug: var=sources.download_url 
+- name: "VAR: Strict Checksum"
+  debug: var=k8s.strict
+
+- name: "VAR: Download Source"
+  debug: var=source.url
+
+- name: "VAR: Checksum"
+  debug: var=source.checksum["{{ k8s.version }}"]
+
 
 #- name: "DEBUG: Variable"
 #  debug: var=rebar

--- a/roles/apiserver/tasks/main.yml
+++ b/roles/apiserver/tasks/main.yml
@@ -5,6 +5,15 @@
 - include: debug.yml
   when: debug
 
+- name: "Download Kubernetes Executables [SLOW]"
+  get_url:
+    dest: "{{bin_dir}}/kube-apiserver"
+    checksum: "{{ item }}"
+    url: "{{ source.url }}/kube-apiserver"
+    validate_certs: yes
+  with_items: "{{ vars['source']['checksum'][k8s.version]['kube-apiserver'] }}"
+  when: source.checksum["{{k8s.version}}"] is defined and k8s.strict|default(true)
+
 - name: install | Write kube-apiserver systemd init file
   template:
     src: "kube-apiserver.service.j2"

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -5,6 +5,15 @@
 - include: debug.yml
   when: debug
 
+- name: "Download Kubernetes Executables [SLOW]"
+  get_url:
+    dest: "{{bin_dir}}/kube-controller-manager"
+    checksum: "{{ item }}"
+    url: "{{ source.url }}/kube-controller-manager"
+    validate_certs: yes
+  with_items: "{{ vars['source']['checksum'][k8s.version]['kube-controller-manager'] }}"
+    when: source.checksum["{{k8s.version}}"] is defined and k8s.strict|default(true)
+
 - name: install | Write kube-controller systemd init file
   template:
     src: "kube-controller.service.j2"

--- a/roles/prereqs/tasks/debug.yml
+++ b/roles/prereqs/tasks/debug.yml
@@ -21,14 +21,5 @@
   debug: var="{{ ansible_os_family|lower }}"
   # required_pkgs.{{ ansible_os_family|lower }}
 
-- name: "VAR: Download Source"
-  debug: var=source.url
-
-- name: "VAR: Strict Checksum"
-  debug: var=k8s.strict
-
-- name: "VAR: Checksum"
-  debug: var=source.checksum["{{ k8s.version }}"]
-
 #- name: "VAR: Variable"
 #  debug: var=rebar

--- a/roles/prereqs/tasks/main.yml
+++ b/roles/prereqs/tasks/main.yml
@@ -69,37 +69,3 @@
       selinux: policy=targeted state=permissive
       when: ansible_os_family == "RedHat"
       changed_when: False
-
-    - name: "Allow downloads without checksum!"
-      fail: msg="not supported yet"
-      when: not k8s.strict
-
-    - name: Create Cache Directory
-      local_action: file path="{{k8s.cache}}/{{k8s.version}}" state=directory mode=0775 recurse=yes
-
-    - name: "Download Kubernetes Executables [SLOW]"
-      local_action:
-        module: get_url
-        dest: "{{k8s.cache}}/{{k8s.version}}/kubernetes.tar.gz"
-        checksum: "{{ item }}"
-        url: "{{ source.url }}"
-        validate_certs: yes
-      with_items: "{{ vars['source']['checksum'][k8s.version] }}"
-      when: source.checksum["{{k8s.version}}"] is defined and k8s.strict
-
-    # ideally, we could do this on the server and just copy the result
-    - name: "Extract All Materials from Archive (step 1/2)"
-      local_action:
-        module: unarchive
-        copy: no
-        src: "{{k8s.cache}}/{{k8s.version}}/kubernetes.tar.gz"
-        dest: "{{k8s.cache}}/{{k8s.version}}"
-        creates: "{{k8s.cache}}/{{k8s.version}}/kubernetes/server/kubernetes-server-linux-amd64.tar.gz"
-
-    - name: "Extract Executables from Archive (step 2/2) [assumes to amd64]"
-      unarchive: 
-        src: "{{k8s.cache}}/{{k8s.version}}/kubernetes/server/kubernetes-server-linux-amd64.tar.gz"
-        dest: /opt
-        owner: "{{ k8s.account }}"
-        mode: u=rx
-        creates: "/opt/kubernetes/server/bin/kubectl"

--- a/roles/prereqs/vars/all.yml
+++ b/roles/prereqs/vars/all.yml
@@ -2,12 +2,6 @@
 # APL v2 Licensed.  Copyright RackN 2016
 # Provides quick way to see all relevant variables
 
-# locations of downloads
-source:
-  url: "https://storage.googleapis.com/kubernetes-release/release/{{ k8s.version }}/kubernetes.tar.gz"
-  checksum:
-    v1.3.3: "sha256:a92a74a0d3f7d02d01ac2c8dfb5ee2e97b0485819e77b2110eb7c6b7c782478c"
-
 centos:
   - libselinux-python
   - device-mapper-libs
@@ -26,3 +20,4 @@ redhat:
   - libselinux-python
   - device-mapper-libs
   - rsync
+

--- a/roles/scheduler/tasks/main.yml
+++ b/roles/scheduler/tasks/main.yml
@@ -5,6 +5,15 @@
 - include: debug.yml
   when: debug
 
+- name: "Download Kubernetes Executables [SLOW]"
+  get_url:
+    dest: "{{bin_dir}}/kube-scheduler"
+    checksum: "{{ item }}"
+    url: "{{ source.url }}/kube-scheduler"
+    validate_certs: yes
+  with_items: "{{ vars['source']['checksum'][k8s.version]['kube-scheduler'] }}"
+    when: source.checksum["{{k8s.version}}"] is defined and k8s.strict|default(true)
+
 - name: install | Write kube-scheduler systemd init file
   template:
     src: "kube-scheduler.service.j2"


### PR DESCRIPTION
downloads just the needed programs by the specific roles that need them
still uses checksums on the files (we just have to calculate them and add to the list)

allowing non-strict checks is TBD

should be faster than the other model which relied on admin server bandwidth.